### PR TITLE
Deprecate '.feature' extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This is the README for the `zombienet-extension`. It assists you writting tests 
 
 ## Usage
 
-Create a file with the `zndsl` extension (or the deprecated `.feature` extension), then using the VScode panel select `Insert Snippet`. Select your snippet and press enter.
+Create a file with the `zndsl` extension, then using the VScode panel select `Insert Snippet`. Select your snippet and press enter.
 Use `TAB` to jump to the next fields.
 
 ## Requirements

--- a/package.json
+++ b/package.json
@@ -31,16 +31,12 @@
       {
         "id": "zndsl",
         "extensions": [
-          ".feature",
           ".zndsl"
         ],
         "aliases": [
           "ZombieNet"
         ]
       }
-    ],
-    "files.associations": {
-      "*.feature": "zndsl"
-    }
+    ]
   }
 }

--- a/package.json
+++ b/package.json
@@ -37,6 +37,9 @@
           "ZombieNet"
         ]
       }
-    ]
+    ],
+    "files.associations": {
+      "*.zndsl": "zndsl"
+    }
   }
 }


### PR DESCRIPTION
Once  zombienet's PR [#427](https://github.com/paritytech/zombienet/pull/427) is merged, we can proceed with merging this one as well, which deprecates the `feature` extension